### PR TITLE
fix: correct percentage display and market status detection

### DIFF
--- a/backend/handlers/ticker_comprehensive.go
+++ b/backend/handlers/ticker_comprehensive.go
@@ -344,6 +344,9 @@ func GetTickerRealTimePrice(c *gin.Context) {
 
 	log.Printf("Success! Got price for %s: %s", symbol, priceData.Price.String())
 
+	// Check if market is currently open
+	isOpen := polygonClient.IsMarketOpen()
+
 	// Return price data directly in ApiClient format
 	c.JSON(http.StatusOK, gin.H{
 		"data": gin.H{
@@ -354,6 +357,10 @@ func GetTickerRealTimePrice(c *gin.Context) {
 			"volume":        priceData.Volume,
 			"timestamp":     priceData.Timestamp.Unix(),
 			"lastUpdated":   priceData.Timestamp.Format(time.RFC3339),
+		},
+		"market": gin.H{
+			"isOpen":         isOpen,
+			"updateInterval": getUpdateInterval(false, map[bool]string{true: "open", false: "closed"}[isOpen]),
 		},
 		"meta": gin.H{
 			"timestamp": time.Now().UTC(),

--- a/backend/services/polygon.go
+++ b/backend/services/polygon.go
@@ -1179,7 +1179,7 @@ func (p *PolygonClient) GetStockRealTimePrice(symbol string) (*models.StockPrice
 	change := decimal.NewFromFloat(currentPrice - prevClose)
 	changePercent := decimal.Zero
 	if prevClose != 0 {
-		changePercent = change.Div(decimal.NewFromFloat(prevClose)).Mul(decimal.NewFromInt(100))
+		changePercent = change.Div(decimal.NewFromFloat(prevClose))
 	}
 
 	// Use today's day data if available, otherwise previous day

--- a/components/ticker/RealTimePriceHeader.tsx
+++ b/components/ticker/RealTimePriceHeader.tsx
@@ -96,7 +96,7 @@ export default function RealTimePriceHeader({ symbol, initialData }: RealTimePri
 
   const formatChange = (change: string, changePercent: string) => {
     const changeNum = parseFloat(change);
-    const changePercentNum = parseFloat(changePercent); // Backend already returns as percentage
+    const changePercentNum = parseFloat(changePercent) * 100; // Backend returns as decimal, convert to percentage
 
     const prefix = changeNum >= 0 ? '+' : '';
     return `${prefix}${changeNum.toFixed(2)} (${prefix}${changePercentNum.toFixed(2)}%)`;

--- a/lib/hooks/useRealTimePrice.ts
+++ b/lib/hooks/useRealTimePrice.ts
@@ -1,0 +1,98 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+
+interface UseRealTimePriceProps {
+  symbol: string;
+  enabled?: boolean;
+}
+
+interface PriceData {
+  price: string;
+  change: string;
+  changePercent: string;
+  volume: number;
+  lastUpdated: string;
+}
+
+export function useRealTimePrice({ symbol, enabled = true }: UseRealTimePriceProps) {
+  const [priceData, setPriceData] = useState<PriceData | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isMarketOpen, setIsMarketOpen] = useState(true);
+  const [isCrypto, setIsCrypto] = useState(false);
+  const [updateInterval, setUpdateInterval] = useState(5000);
+  const intervalRef = useRef<NodeJS.Timeout>();
+
+  useEffect(() => {
+    if (!enabled || !symbol) return;
+
+    const fetchPrice = async () => {
+      try {
+        // First try crypto endpoint
+        const cryptoResponse = await fetch(`/api/v1/crypto/${symbol}/price`);
+
+        if (cryptoResponse.ok) {
+          const data = await cryptoResponse.json();
+          setIsCrypto(true);
+          setIsMarketOpen(true); // Crypto markets are always open
+          setUpdateInterval(data.update_interval || 5000);
+
+          setPriceData({
+            price: String(data.price),
+            change: String(data.price * data.change_24h / 100),
+            changePercent: String(data.change_24h / 100),
+            volume: data.volume_24h || 0,
+            lastUpdated: data.last_updated || new Date().toISOString()
+          });
+
+          setError(null);
+          return;
+        }
+
+        // Fall back to regular ticker endpoint for stocks
+        const response = await fetch(`/api/v1/tickers/${symbol}/realtime`);
+
+        if (!response.ok) {
+          throw new Error(`Failed to fetch price: ${response.status}`);
+        }
+
+        const result = await response.json();
+        setIsCrypto(false);
+        setIsMarketOpen(result.market?.isOpen ?? false);
+        setUpdateInterval(result.market?.updateInterval || 15000);
+
+        setPriceData({
+          price: result.data.price,
+          change: result.data.change,
+          changePercent: result.data.changePercent,
+          volume: result.data.volume,
+          lastUpdated: result.data.lastUpdated
+        });
+
+        setError(null);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to fetch price');
+      }
+    };
+
+    // Initial fetch
+    fetchPrice();
+
+    // Set up polling
+    intervalRef.current = setInterval(fetchPrice, updateInterval);
+
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+      }
+    };
+  }, [symbol, enabled, updateInterval]);
+
+  return {
+    priceData,
+    error,
+    isMarketOpen,
+    isCrypto,
+    updateInterval
+  };
+}


### PR DESCRIPTION
- Remove double multiplication of percentage in polygon.go (was multiplying by 100 twice)
- Update frontend to multiply by 100 for display (backend now returns decimal)
- Add market status (isOpen) to realtime price API response
- Fix useRealTimePrice hook to read market status from correct response path
- Change default market status to false when not available

🤖 Generated with [Claude Code](https://claude.com/claude-code)